### PR TITLE
🚨 hotfix: fix version update script for agents-sdk dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,9 @@ jobs:
       run: |
         # Update all crate versions to match the tag
         sed -i 's/^version = "0.0.1"/version = "${{ steps.version.outputs.VERSION }}"/' crates/*/Cargo.toml
-        # Update workspace dependency versions
+        # Update workspace dependency versions (format: version = "0.0.1", path = ...)
+        sed -i 's/version = "0.0.1", path =/version = "${{ steps.version.outputs.VERSION }}", path =/g' crates/*/Cargo.toml
+        # Update workspace dependency versions (format: , version = "0.0.1")
         sed -i 's/, version = "0.0.1"/, version = "${{ steps.version.outputs.VERSION }}"/' crates/*/Cargo.toml
     - name: Publish agents-core
       run: cargo publish -p agents-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## 🚨 Critical Hotfix: Version Update Script

This hotfix resolves the CI failure in v0.0.2 deployment where `agents-sdk` dependencies had version mismatches.

### 🐛 **Root Cause**
The CI version update script only handled these patterns:
- `^version = "0.0.1"` (main package version)
- `, version = "0.0.1"` (some dependency formats)

But `agents-sdk` uses this format:
```toml
agents-core = { version = "0.0.1", path = "../agents-core" }
```

### ✅ **Fix**
Added sed command to handle the `agents-sdk` dependency format:
```bash
sed -i 's/version = "0.0.1", path =/version = "$VERSION", path =/g' crates/*/Cargo.toml
```

This ensures all dependency versions are updated correctly during release.

### 📋 **Testing**
- Verified pattern matches `agents-sdk/Cargo.toml` format
- Handles all dependency patterns now
- No functional code changes

🚨 **URGENT**: Need to merge this and retag v0.0.2 to complete the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)